### PR TITLE
Typo fix

### DIFF
--- a/entity-manager.html
+++ b/entity-manager.html
@@ -97,7 +97,7 @@
                 <a class="anchor" href="#api.entityManager.preload"><svg aria-hidden="true" height="16" version="1.1" viewBox="0 0 16 16" width="16"><path d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"></path></svg></a>
                 <code class="language-typescript">preload(target: Function|string, object: Object): Promise&lt;Entity&gt;</code>
                 <p>
-                    Creates a new entity from the given plan javascript object. If entity already exist in the database, then
+                    Creates a new entity from the given plan JavaScript object. If entity already exist in the database, then
                     it loads it (and everything related to it), replaces all values with the new ones from the given object
                     and returns this new entity. This new entity is actually a loaded from the db entity with all properties
                     replaced from the new object.

--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@
         <ul>
             <li>automatically create the database table schemes based on your models</li>
             <li>transparently insert / update / delete to the database your objects</li>
-            <li>map your selections from tables to javascript objects and map table columns
+            <li>map your selections from tables to JavaScript objects and map table columns
                 to object properties</li>
             <li>easily create one-to-one, many-to-one, one-to-many and many-to-many relations between tables</li>
             <li>and much more...</li>
@@ -75,7 +75,7 @@
 
         <p>
             TypeORM uses the <a href="https://en.wikipedia.org/wiki/Data_mapper_pattern">data mapper pattern</a>,
-            unlike all other javascript ORMs that currently exist, which means you can write loosely coupled, scalable,
+            unlike all other JavaScript ORMs that currently exist, which means you can write loosely coupled, scalable,
             maintainable applications. The benefit of using an ORM is ability to focus on the business logic (your application)
             and less on the persistence layer (your database).
         </p>

--- a/repository.html
+++ b/repository.html
@@ -124,7 +124,7 @@
                 <a class="anchor" href="#api.repository.preload"><svg aria-hidden="true" height="16" version="1.1" viewBox="0 0 16 16" width="16"><path d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"></path></svg></a>
                 <code class="language-typescript">preload(object: Object): Promise&lt;Entity&gt;</code>
                 <p>
-                    Creates a new entity from the given plan javascript object. If entity already exist in the database, then
+                    Creates a new entity from the given plan JavaScript object. If entity already exist in the database, then
                     it loads it (and everything related to it), replaces all values with the new ones from the given object
                     and returns this new entity. This new entity is actually a loaded from the db entity with all properties
                     replaced from the new object.

--- a/tables-and-columns.html
+++ b/tables-and-columns.html
@@ -530,7 +530,7 @@ export class Category {
         </h4>
 
         <p>
-            Concrete table inheritance is possible throw the child classes decorated with <code>@AbstractEntity</code> decorator.
+            Concrete table inheritance is possible through the child classes decorated with <code>@AbstractEntity</code> decorator.
             Example:
         </p>
 


### PR DESCRIPTION
This PR fixes a small typo on "Tables and columns" section and replaces occurrences of "javascript" with "JavaScript".