### PR TITLE
Typo in migration**s** directory vs configuration

### DIFF
--- a/migrations.html
+++ b/migrations.html
@@ -61,7 +61,7 @@
         <h3>Example</h3>
 
         <p>
-            First, create <code>migrations</code> directory, where you'll create a migrations.
+            First, create <code>migration</code> directory, where you'll create a migrations.
             Also you'll need to setup migrations directory in your connection options:
         </p>
 


### PR DESCRIPTION
Doc says :
> First, create <code>migration**s**</code> directory, where you'll create a migrations.  

vs proposed configuration using "migration" directory without **s**:
```
 migrations: [
        __dirname + "/migration/*.js"
    ],
    cli: {
        migrationsDir: __dirname + "/migration"
    }
```