### PR TITLE
Added another converter for links to a different page, added scroll to top

### DIFF
--- a/script/component/MarkdownReader.js
+++ b/script/component/MarkdownReader.js
@@ -25,6 +25,8 @@ const MarkdownReader = {
             const fragmentElement = document.getElementById(fragment);
             if (fragmentElement)
                 fragmentElement.scrollIntoView();
+            else
+                window.scrollTo(0, 0);
         },
         loadFile: function(file) {
             return fetch(file)
@@ -53,7 +55,15 @@ const MarkdownReader = {
                         }];
                     });
 
-                    const converter = new showdown.Converter({ extensions: ['header-anchors', 'links-replacer'] });
+                    showdown.extension('other-page-links-replacer', () => {
+                        return [{
+                            type: "html",
+                            regex: /<a href="\.\/?(.*)\.md\/?(.*)">/g,
+                            replace: "<a href='#/$1/$2'>"
+                        }];
+                    });
+
+                    const converter = new showdown.Converter({ extensions: ['header-anchors', 'links-replacer', 'other-page-links-replacer'] });
                     converter.setFlavor('github');
                     converter.setOption('simpleLineBreaks', false);
 


### PR DESCRIPTION
With this PR links to a different page have to me formated in one of these ways:
```
file.md
./file.md
file.md#header
./file.md#header
```
This would mean, that they also work in the docs folder in typeorm/typeorm and on the website and you don't have to follow a special syntax.
I also added a `scrollToTop` if no fragment is found. This will scroll to the top of the page if you navigate to a new page without a special header to jump to