### PR TITLE
Fixed regex that parses links to another site

### DIFF
--- a/script/component/MarkdownReader.js
+++ b/script/component/MarkdownReader.js
@@ -58,8 +58,8 @@ const MarkdownReader = {
                     showdown.extension('other-page-links-replacer', () => {
                         return [{
                             type: "html",
-                            regex: /<a href="\.\/?(.*)\.md\/?(.*)">/g,
-                            replace: "<a href='#/$1/$2'>"
+                            regex: /<a href="(\.\/)?(.*)\.md\/?(.*)">/g,
+                            replace: "<a href='#/$2/$3'>"
                         }];
                     });
 


### PR DESCRIPTION
I messed the regex up.
The current version only supports `./entities.md` and not `entities.md` because `?` is only applied to "/" and not "."