### PR TITLE
Links: README.md

### DIFF
--- a/script/component/DocumentPage.js
+++ b/script/component/DocumentPage.js
@@ -40,7 +40,7 @@ const DocumentPage = {
             if (this.document === "changelog") {
                 return `https://raw.githubusercontent.com/typeorm/typeorm/master/CHANGELOG.md`;
 
-            } else if (!this.document) {
+            } else if (!this.document || this.document === "readme") {
                 return `https://raw.githubusercontent.com/typeorm/typeorm/master/README.md`;
 
             } else {

--- a/script/component/MarkdownReader.js
+++ b/script/component/MarkdownReader.js
@@ -4,6 +4,7 @@ const MarkdownReader = {
     data: function() {
         return {
             html: "",
+            document: "readme"
         }
     },
     watch: {
@@ -15,6 +16,10 @@ const MarkdownReader = {
         }
     },
     created: function () {
+        if(this.$route.params.document) {
+            this.document = this.$route.params.document;
+        }
+
         this.loadFile(this.file)
             .then(() => {
                 this.scrollToFragment(this.fragment);
@@ -51,14 +56,14 @@ const MarkdownReader = {
                         return [{
                             type: "html",
                             regex: /<a href="#(.*)">/g,
-                            replace: "<a href='#" + this.$route.params.document + "/$1'>"
+                            replace: "<a href='#" + this.document + "/$1'>"
                         }];
                     });
 
                     showdown.extension('other-page-links-replacer', () => {
                         return [{
                             type: "html",
-                            regex: /<a href="(\.\/)?(.*)\.md\/?(.*)">/g,
+                            regex: /<a href="\.?\/?(docs\/)?(.*)\.md\#?(.*)">/g,
                             replace: "<a href='#/$2/$3'>"
                         }];
                     });


### PR DESCRIPTION
this regex has been tested with these links:
```html
<a href="file.md">
<a href="./file.md">
<a href="file.md#header">
<a href="./file.md#header">
<a href="./docs/file.md">
<a href="./docs/file.md#header">
<a href="/docs/file.md#header">
<a href="/docs/file.md">
```
and they all link to #/file/header (if header is set, otherwise #/file).

Also the links to a header within README.md work and link to #/readme/header. This is not the best solution but in my opinion better than adding new routes