### PR TITLE
fix(subheader): navigation of subheader doesn't change to new page

### DIFF
--- a/script/component/MarkdownReader.js
+++ b/script/component/MarkdownReader.js
@@ -9,6 +9,13 @@ const MarkdownReader = {
     },
     watch: {
         'file': function(file) {
+            if(this.$route.params.document) {
+                this.document = this.$route.params.document;
+            }
+            else {
+                this.document = "readme";
+            }
+
             this.loadFile(file);
         },
         'fragment': function(fragment) {
@@ -16,10 +23,6 @@ const MarkdownReader = {
         }
     },
     created: function () {
-        if(this.$route.params.document) {
-            this.document = this.$route.params.document;
-        }
-
         this.loadFile(this.file)
             .then(() => {
                 this.scrollToFragment(this.fragment);
@@ -50,7 +53,6 @@ const MarkdownReader = {
                             replace: ancTpl
                         }];
                     });
-
 
                     showdown.extension('links-replacer', () => {
                         return [{


### PR DESCRIPTION
I messed up again...

When navigating to a new page, `this.document` stays the same since `created` is only called once. But is should the updated every time the `file` prop changed. Sorry...