### PR TITLE
Allow left panel to scroll independently

### DIFF
--- a/script/component/MainPage.js
+++ b/script/component/MainPage.js
@@ -60,7 +60,7 @@ const MainPage = {
         </div>
     </nav>
     <div class="row">
-        <div class="col-12 col-sm-5 col-md-4 left-panel">
+        <div class="col-12 col-sm-5 col-md-4 left-panel sticky-top">
             <ul>
                 <li v-for="link in links">
                     <div v-if="link.links">

--- a/style/app.css
+++ b/style/app.css
@@ -60,6 +60,11 @@ h1 code, h2 code, h3 code {
     border-bottom: 1px solid #EEE;
 }
 
+.left-panel {
+  max-height: 100vh;
+  overflow-y: auto;
+}
+
 .left-panel ul {
     list-style: none;
     line-height: 28px;


### PR DESCRIPTION
Closes #32 
Currently the left panel, which contains links to different sections in the docs, scrolls along with the main content and hence becomes invisible if the height of main content section is big enough (which usually is the case). This adds unnecessary friction for the reader.

This PR allows the left panel to scroll independent of the main content, which means the links are always visible to the reader for easy navigation.

![image](https://user-images.githubusercontent.com/6953187/90346119-ea816280-e043-11ea-9a6b-87f6d9722651.png)
