### PR TITLE
update showdown to 1.9.1 & enable metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,8 +39,8 @@
 <script src="https://unpkg.com/vue-router/dist/vue-router.js"></script> <!--node_modules/vue-router/dist/vue-router.min.js-->
 <script src="https://unpkg.com/vue-i18n/dist/vue-i18n.js"></script><!--node_modules/vue-i18n/dist/vue-i18n.js-->
 <script src="https://unpkg.com/vue-cookies/vue-cookies.js"></script><!--node_modules/vue-cookies/dist/vue-cookies.js-->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/showdown/1.7.4/showdown.min.js"></script> <!--node_modules/prismjs/prism.js-->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.8.1/prism.min.js"></script> <!--node_modules/showdown/dist/showdown.js-->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/showdown/1.9.1/showdown.min.js"></script> <!--node_modules/showdown/dist/showdown.js-->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.8.1/prism.min.js"></script> <!--node_modules/prismjs/prism.js-->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.8.1/components/prism-typescript.min.js"></script> <!--node_modules/prismjs/components/prism-typescript.js-->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.8.1/components/prism-json.min.js"></script> <!--node_modules/prismjs/components/prism-typescript.js-->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.8.1/components/prism-sql.min.js"></script> <!--node_modules/prismjs/components/prism-typescript.js-->

--- a/script/component/MarkdownReader.js
+++ b/script/component/MarkdownReader.js
@@ -76,7 +76,7 @@ const MarkdownReader = {
                         }];
                     });
 
-                    const converter = new showdown.Converter({ extensions: ['header-anchors', 'links-replacer', 'other-page-links-replacer'] });
+                    const converter = new showdown.Converter({ metadata: true, extensions: ['header-anchors', 'links-replacer', 'other-page-links-replacer'] });
                     converter.setFlavor('github');
                     converter.setOption('simpleLineBreaks', false);
 


### PR DESCRIPTION
This allows for frontmatter to be added to documentation.  This means if we wanted to add metadata to the markdown for more dynamic categories, language codes, tags, etc - we could!