### PR TITLE
fix responsiveness issue

### DIFF
--- a/style/app.css
+++ b/style/app.css
@@ -238,3 +238,8 @@ ol {
     width: 100%;
   }
 }
+
+img {
+  max-width: 100%;
+  height: auto;
+}


### PR DESCRIPTION
Currently, the images on the website do not scale down when screen size shrinks. This makes the website horizontally scrollable which it should not be.

## Problem
![image](https://user-images.githubusercontent.com/4337699/113708621-177fa400-96ff-11eb-9b27-374cbaacc854.png)

## Fix after this PR
![image](https://user-images.githubusercontent.com/4337699/113708695-2ebe9180-96ff-11eb-96b8-670086ea3d2e.png)
