### PR TITLE
feat: add Algolia DocSearch to documentation site

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en" data-framework="typescript">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <script>
+        // since the site is a single page application,
+        // replace the current url to point to index.html with the entire path as a query property
+        // so index.html could put the path back into the current url wia the history api
+        window.location.replace(
+            window.location.origin + "/?path=" + encodeURIComponent(window.location.href.substring(window.location.origin.length))
+        );
+    </script>
+
+    <link rel="apple-touch-icon" sizes="180x180" href="image/favicon/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="image/favicon/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="image/favicon/favicon-16x16.png">
+    <link rel="manifest" href="image/favicon/manifest.json">
+    <link rel="mask-icon" href="image/favicon/safari-pinned-tab.svg" color="#666666">
+    <meta name="theme-color" content="#ffffff">
+    <title>
+        TypeORM - Amazing ORM for TypeScript and JavaScript (ES7, ES6, ES5). Supports MySQL, PostgreSQL, MariaDB, SQLite, MS SQL Server, Oracle, WebSQL databases. Works in NodeJS, Browser, Ionic, Cordova and Electron platforms.
+    </title>
+</head>
+<body>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
     <link rel="stylesheet" href="style/app.css">
     <link rel="stylesheet" href="style/prism.css">
     <link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@docsearch/css@3" />
     <link rel="apple-touch-icon" sizes="180x180" href="image/favicon/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="image/favicon/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="image/favicon/favicon-16x16.png">
@@ -45,6 +46,7 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.8.1/components/prism-json.min.js"></script> <!--node_modules/prismjs/components/prism-typescript.js-->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.8.1/components/prism-sql.min.js"></script> <!--node_modules/prismjs/components/prism-typescript.js-->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/fetch/2.0.3/fetch.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@docsearch/js@3"></script> <!-- Algolia DocSearch -->
 
 <script src="script/constant/Links.js"></script>
 <script src="locale/en.js"></script>

--- a/index.html
+++ b/index.html
@@ -5,6 +5,14 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
+    <script>
+        // if the current page was redirected from 404.html, put the path back in the url via the history api
+        if (window.location.href.substring(window.location.origin.length).startsWith("/?path="))
+            window.history.replaceState(null, document.title, window.location.origin + decodeURIComponent(
+                window.location.href.substring(window.location.origin.length + "/?path=".length)
+            ));
+    </script>
+
     <link rel="stylesheet"
           href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.1/css/bootstrap.min.css"
           integrity="sha384-WskhaSGFgHYWDcbwN70/dfYBj47jz9qbsMId/iRN3ewGhXQFZCSftd1LZCfmhktB"

--- a/script/component/DocumentPage.js
+++ b/script/component/DocumentPage.js
@@ -1,7 +1,7 @@
 const DocumentPage = {
     template: `
 <div class="document">
-    <markdown-reader :file="readUrl" :fragment="fragment"></markdown-reader>
+    <markdown-reader :file="readUrl" :hash="hash"></markdown-reader>
     
     <div class="contribute small">
         {{$t("contribute")}} <a :href="editUrl">{{$t("edit")}}</a>
@@ -11,7 +11,7 @@ const DocumentPage = {
     data: function() {
         return {
             document: this.$route.params.document,
-            fragment: this.$route.params.fragment,
+            hash: this.$route.hash,
             locale: $cookies.get("locale") || "en",
             readLink: "https://raw.githubusercontent.com/typeorm/typeorm/master/",
             editLink: "https://github.com/typeorm/typeorm/edit/master/"
@@ -20,7 +20,7 @@ const DocumentPage = {
     watch: {
         '$route': function(to, from) {
             this.document = to.params.document;
-            this.fragment = to.params.fragment;
+            this.hash = to.hash;
             this.updateTitle();
         }
     },

--- a/script/component/MainPage.js
+++ b/script/component/MainPage.js
@@ -108,9 +108,9 @@ const MainPage = {
 
         docsearch({
             container: '#docsearch',
-            appId: 'YOUR_APP_ID', // TODO: replace with `appId` from https://docsearch.algolia.com/apply/
-            indexName: 'YOUR_INDEX_NAME', // TODO: replace with `indexName` from https://docsearch.algolia.com/apply/
-            apiKey: 'YOUR_SEARCH_API_KEY' // TODO: replace with `apiKey` from https://docsearch.algolia.com/apply/
+            appId: '2UUKVSBT3M',
+            indexName: 'typeorm',
+            apiKey: '8392de2c2e76d873b60bf10562aab788'
         });
     },
     methods: {

--- a/script/component/MainPage.js
+++ b/script/component/MainPage.js
@@ -25,6 +25,9 @@ const MainPage = {
                             </svg>
                         </a>
                     </li>-->
+                    <li class="nav-item" style="margin-inline-end: 16px">
+                        <div id="docsearch"></div>
+                    </li>
                     <li class="nav-item">
                         <a class="nav-link" href="https://join.slack.com/t/typeorm/shared_invite/zt-uu12ljeb-OH_0086I379fUDApYJHNuw" title="Slack">
                             <svg aria-labelledby="simpleicons-slack-icon" role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="#FF0064">
@@ -102,6 +105,13 @@ const MainPage = {
          scriptEl.setAttribute('id', '_carbonads_js');
          scriptEl.setAttribute('async', null);
          this.$refs.carbon.appendChild(scriptEl);
+
+        docsearch({
+            container: '#docsearch',
+            appId: 'YOUR_APP_ID', // TODO: replace with `appId` from https://docsearch.algolia.com/apply/
+            indexName: 'YOUR_INDEX_NAME', // TODO: replace with `indexName` from https://docsearch.algolia.com/apply/
+            apiKey: 'YOUR_SEARCH_API_KEY' // TODO: replace with `apiKey` from https://docsearch.algolia.com/apply/
+        });
     },
     methods: {
         goToLink: function () {

--- a/script/component/MarkdownReader.js
+++ b/script/component/MarkdownReader.js
@@ -68,7 +68,7 @@ const MarkdownReader = {
                         return [{
                             type: "html",
                             regex: /<a href="#(.*)">/g,
-                            replace: "<a href='/" + this.document + "#$1'>"
+                            replace: "<a href='/" + (this.document ? this.document + "#" : "") + "$1'>"
                         }];
                     });
 

--- a/script/component/MarkdownReader.js
+++ b/script/component/MarkdownReader.js
@@ -1,6 +1,6 @@
 const MarkdownReader = {
     template: `<div v-html="html"></div>`,
-    props: ["file", "fragment"],
+    props: ["file", "hash"],
     data: function() {
         return {
             html: "",
@@ -12,27 +12,31 @@ const MarkdownReader = {
             this.setDocument();
             this.loadFile(file)
                 .then(() => {
-                    this.scrollToFragment(this.fragment);
+                    this.scrollToHash(this.hash);
                 });
         },
-        'fragment': function(fragment) {
-            this.scrollToFragment(fragment);
+        'hash': function(hash) {
+            this.scrollToHash(hash);
         }
     },
     created: function () {
         this.setDocument();
         this.loadFile(this.file)
             .then(() => {
-                this.scrollToFragment(this.fragment);
+                this.scrollToHash(this.hash);
             });
     },
     methods: {
-        scrollToFragment: function(fragment) {
-            const fragmentElement = document.getElementById(fragment);
-            if (fragmentElement)
-                fragmentElement.scrollIntoView();
-            else
-                window.scrollTo(0, 0);
+        scrollToHash: function(hash) {
+            if (hash) {
+                const fragmentElement = document.getElementById(hash.substring("#".length));
+                if (fragmentElement) {
+                    fragmentElement.scrollIntoView();
+                    return;
+                }
+            }
+
+            window.scrollTo(0, 0);
         },
         setDocument: function () {
             if(this.$route.params.document) {
@@ -51,7 +55,7 @@ const MarkdownReader = {
 
                     showdown.extension('header-anchors', () => {
 
-                        var ancTpl = '$1<a id="user-content-$3" class="anchor" href="#' + this.$route.params.document + '/$3" aria-hidden="true">#</a> $4';
+                        var ancTpl = '$1<a id="user-content-$3" class="anchor" href="#$3" aria-hidden="true">#</a> $4';
 
                         return [{
                             type: "html",
@@ -64,7 +68,7 @@ const MarkdownReader = {
                         return [{
                             type: "html",
                             regex: /<a href="#(.*)">/g,
-                            replace: "<a href='#/" + this.document + "/$1'>"
+                            replace: "<a href='/" + this.document + "#$1'>"
                         }];
                     });
 
@@ -72,7 +76,7 @@ const MarkdownReader = {
                         return [{
                             type: "html",
                             regex: /<a href="\.?\/?(docs\/)?(.*?)\.md\#?(.*?)">/g,
-                            replace: "<a href='#/$2/$3'>"
+                            replace: "<a href='/$2#$3'>"
                         }];
                     });
 

--- a/script/index.js
+++ b/script/index.js
@@ -11,14 +11,30 @@ const i18n = new VueI18n({
   messages // set locale messages
 })
 
+const router = new VueRouter({
+  mode: "history",
+  routes: [
+    { path: "/:document?/:fragment?", component: DocumentPage },
+  ]
+});
+
+// Because the documentation previously used "hash" mode in the Router, paths
+// starting with a hash will be redirected to prevent breaking old permalinks.
+router.beforeEach((to, from, next) => {
+  if (to.fullPath.startsWith("/#/")) {
+    // Remove leading hash and replace following slash with hash.
+    // Before: https://typeorm.io/#/entities/entity-columns
+    // After:  https://typeorm.io/entities#entity-columns
+    const path = "/" + to.fullPath.substring("/#/".length).replace("/", "#");
+    next(path);
+  } else
+    next();
+});
+
 new Vue({
   el: "#app",
   i18n,
-  router: new VueRouter({
-    routes: [
-      { path: "/:document?/:fragment?", component: DocumentPage },
-    ]
-  }),
+  router: router,
   components: {
     "main-page": MainPage,
     "markdown-reader": MarkdownReader,


### PR DESCRIPTION
# Description
### Added Algolia DocSearch to the documentation site
> The screenshots below use the testing `apiKey` provided by Algolia

In order for the search to actually work you have to do the following:
1. Go to https://docsearch.algolia.com/apply/ and register TypeORM, it's free for open-source projects.
2. Edit `apiKey`, `appId` and `indexName` in `script/component/MainPage.js` with the values provided to you by Algolia.

Closes: #16 

### Changed Vue router's mode from "hash" to "history" to support search engine indexing
Previously site URLs looked like this:
```txt
https://typeorm.io/#/data-source
https://typeorm.io/#/data-source/how-to-use-datasource
```

Now site URLs will look like this:
```txt
https://typeorm.io/data-source
https://typeorm.io/data-source#how-to-use-datasource
```

The previous URLs will continue to work but will now redirect to the new URLs.
In order to prevent getting a 404 error when opening a deep URL, a custom `404.html` page is implemented to redirect back to `index.html` which will then use the history API to load the original URL without a refresh.

Based on #36

# Screenshots
![localhost_3000_ (2)](https://user-images.githubusercontent.com/7817232/159367936-2130403f-1b22-467e-a89c-64524b3b027f.png)

![localhost_3000_ (3)](https://user-images.githubusercontent.com/7817232/159367951-c667d33e-809b-4bc8-92c8-497b1c00f66b.png)

![localhost_3000_ (4)](https://user-images.githubusercontent.com/7817232/159367968-5341703a-fe5a-486c-a482-7644ed6f7a19.png)