### PR TITLE
fix: link urls to external `.md` files

### DIFF
--- a/script/component/MarkdownReader.js
+++ b/script/component/MarkdownReader.js
@@ -71,7 +71,7 @@ const MarkdownReader = {
                     showdown.extension('other-page-links-replacer', () => {
                         return [{
                             type: "html",
-                            regex: /<a href="\.?\/?(docs\/)?(.*?)\.md\#?(.*?)">/g,
+                            regex: /<a href="(?!https?\:)\.?\/?(docs\/)?(.*?)\.md\#?(.*?)">/g,
                             replace: "<a href='#/$2/$3'>"
                         }];
                     });


### PR DESCRIPTION
Make links such as `https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md` direct to the link itself and not to `https://typeorm.io/https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md`