### PR TITLE
fix: page title

### DIFF
--- a/script/component/DocumentPage.js
+++ b/script/component/DocumentPage.js
@@ -28,15 +28,31 @@ const DocumentPage = {
             this.updateTitle();
         }
     },
-    create: function() {
+    mounted() {
         this.updateTitle();
     },
     methods: {
-        updateTitle: function() {
-            const link = this.$t("links").find(link => link.url === this.document);
-            if (link) {
-                window.document.title = link.name + " | TypeORM";
+        getCurrentDocumentName(links = Links) {
+            for (const link of links) {
+                if (link.url === this.document)
+                    return link.name;
+                else if (link.links instanceof Array) {
+                    const res = this.getCurrentDocumentName(link.links);
+                    if (res != null)
+                        return res;
+                }
             }
+
+            return null;
+        },
+        updateTitle: function() {
+            const documentName = this.getCurrentDocumentName();
+            if (!this.document)
+                document.title = this.$t("title");
+            else if (documentName)
+                window.document.title = documentName + " | TypeORM";
+            else
+                document.title = this.$t("title");
         }
     },
     components: {

--- a/script/index.js
+++ b/script/index.js
@@ -41,6 +41,5 @@ new Vue({
   },
   mounted: function () {
     i18n.locale = $cookies.get("locale") || "en";
-    document.title = this.$t("title");
   }
 });

--- a/style/app.css
+++ b/style/app.css
@@ -243,3 +243,7 @@ img {
   max-width: 100%;
   height: auto;
 }
+
+.DocSearch mark {
+    padding: initial;
+}


### PR DESCRIPTION
Previously the page title was always the same one as the main page, now all pages have a proper page title.
This also helps the search index.

```typescript
"/" => "TypeORM - Amazing ORM for TypeScript and JavaScript (ES7, ES6, ES5). Supports MySQL, PostgreSQL, MariaDB, SQLite, MS SQL Server, Oracle, WebSQL databases. Works in NodeJS, Browser, Ionic, Cordova and Electron platforms."
"/data-source" => "Working with Data Source | TypeORM"
```