### PR TITLE
docs: add `safe-typeorm` corner under `query-builder`

### DIFF
--- a/locale/en.js
+++ b/locale/en.js
@@ -109,6 +109,9 @@ const locale_en = {
         }, {
             url: "caching",
             name: "Caching Results"
+        }, {
+            url: "safe-typeorm",
+            name: "(extension) Safe-TypeORM"
         }]
     }, {
         name: "Advanced Topics",


### PR DESCRIPTION
Documentation PR about typeorm/typeorm#9868 that adding `safe-typeorm` corner under `query-builder` section.