### PR TITLE
bump: vue-cookies to `v1.8.3`

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
 <script src="https://unpkg.com/vue@2/dist/vue.min.js"></script> <!--node_modules/vue/dist/vue.min.js-->
 <script src="https://unpkg.com/vue-router@2/dist/vue-router.js"></script> <!--node_modules/vue-router/dist/vue-router.min.js-->
 <script src="https://unpkg.com/vue-i18n@8.23.0/dist/vue-i18n.js"></script><!--node_modules/vue-i18n/dist/vue-i18n.js-->
-<script src="https://unpkg.com/vue-cookies/vue-cookies.js"></script><!--node_modules/vue-cookies/dist/vue-cookies.js-->
+<script src="https://unpkg.com/vue-cookies@1.8.3/vue-cookies.js"></script><!--node_modules/vue-cookies/dist/vue-cookies.js-->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/showdown/1.9.1/showdown.min.js"></script> <!--node_modules/showdown/dist/showdown.js-->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.8.1/prism.min.js"></script> <!--node_modules/prismjs/prism.js-->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.8.1/components/prism-typescript.min.js"></script> <!--node_modules/prismjs/components/prism-typescript.js-->


### PR DESCRIPTION
- link no more exist
- use latest version of vue-cookies
- web site down due to this issue